### PR TITLE
updated parameter option in .sql file notation changed windows sqlcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cat script.sql | sqlcmd -s 127.0.0.1 -u sa -p p@ssw0rd
 Run a script and supply template parameter values:
 
 ```
-sqlcmd -s 127.0.0.1 -u sa -p p@ssw0rd "select name from sys.databases where database_id = <database_id,int,>" -m database_id=1
+sqlcmd -s 127.0.0.1 -u sa -p p@ssw0rd "select name from sys.databases where database_id = $(database_id)" -m database_id=1
 ```
 
 ## Version History

--- a/sqlcmd.js
+++ b/sqlcmd.js
@@ -87,8 +87,8 @@ function replaceTemplateParams(script, callback) {
     return [match[1], match[2]];
   }));
 
-  var script = script.replace(/<([\w-]+),\s*(\w*),\s*(\w*)>/g, function(match, name, type, defaultValue) {
-    var value = params[name] || defaultValue;
+  var script = script.replace(/\$\((\w*)\)/g, function(match, name) {
+    var value = params[name];
 
     if (!value)
       return callback(new Error('No value for param: ' + name));


### PR DESCRIPTION
Please review my fix for the following issue:

https://github.com/soheilpro/sqlcmd/issues/4