### PR TITLE
Added Port option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Run a script and supply template parameter values using the sqlcmd.exe format:
 sqlcmd -s 127.0.0.1 -u sa -p p@ssw0rd "select name from sys.databases where database_id = $(database_id)" -m database_id=1
 ```
 
-
 ## Version History
++ **1.5**
+  + Added port option
 + **1.4**
   + Added support for Windows domains.
   + Added support for sqlcmd.exe style template parameters. (Thanks [gunesmes](https://github.com/gunesmes))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -g sqlcmdjs
 ## Usage
 
 ```
-sqlcmd -s <server> -u [<domain>\]<username> -p <password> [-d <database>] [-t <timeout>] [-m param1=foo -m param2=bar ...] <script>
+sqlcmd -s <server> -u [<domain>\]<username> -p <password> [-o <port>] [-d <database>] [-t <timeout>] [-m param1=foo -m param2=bar ...] <script>
 ```
 
 If no script is specified, sqlcmd reads from the standard input.
@@ -40,6 +40,7 @@ Run a script and supply template parameter values using the sqlcmd.exe format:
 ```
 sqlcmd -s 127.0.0.1 -u sa -p p@ssw0rd "select name from sys.databases where database_id = $(database_id)" -m database_id=1
 ```
+
 
 ## Version History
 + **1.4**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlcmdjs",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "sqlcmd for Mac and Linux.",
   "main": "sqlcmd.js",
   "dependencies": {

--- a/sqlcmd.js
+++ b/sqlcmd.js
@@ -10,17 +10,19 @@ var argv = require('optimist')
     .alias('s', 'server')
     .alias('u', 'user')
     .alias('p', 'password')
+    .alias('o', 'port')
     .alias('d', 'database')
     .alias('t', 'timeout')
     .alias('m', 'param')
     .describe('s', '')
     .describe('u', '')
     .describe('p', '')
+    .describe('o', 'Default: 1433')
     .describe('d', 'Default: master')
     .describe('t', 'Default: 60 seconds')
     .describe('m', 'Format: param1=foo')
     .usage('Usage:' + eol +
-           '  sqlcmd -s <server> -u <username> -p <password> [-d <database>] [-t <timeout>] [-m param1=foo -m param2=bar ...] <script>')
+           '  sqlcmd -s <server> -u <username> -p <password> [-o <port>] [-d <database>] [-t <timeout>] [-m param1=foo -m param2=bar ...] <script>')
     .argv;
 
 getScript(function(error, script) {
@@ -121,6 +123,7 @@ function connectToServer(callback) {
     domain: argv.domain,
     user: argv.user,
     password: argv.password,
+    port: argv.port || 1433,
     database: argv.database || 'master',
     requestTimeout: (argv.timeout || 60) * 1000
   }


### PR DESCRIPTION
Pretty self explanatory

sqlcmd
Usage:
  sqlcmd -s <server> -u <username> -p <password> [-o <port>] [-d <database>] [-t <timeout>] [-m param1=foo -m param2=bar ...] <script>

Options:
  -s, --server                         [required]
  -u, --user                           [required]
  -p, --password                       [required]
  -o, --port      Default: 1433
  -d, --database  Default: master
  -t, --timeout   Default: 60 seconds
  -m, --param     Format: param1=foo

Missing required arguments: s, u, p